### PR TITLE
Update the terraform provider

### DIFF
--- a/connectors/terraform/provider/client.go
+++ b/connectors/terraform/provider/client.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"encoding/base64"

--- a/connectors/terraform/provider/client_test.go
+++ b/connectors/terraform/provider/client_test.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"fmt"

--- a/connectors/terraform/provider/common.go
+++ b/connectors/terraform/provider/common.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"bytes"

--- a/connectors/terraform/provider/data_source_item.go
+++ b/connectors/terraform/provider/data_source_item.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/data_source_item_type.go
+++ b/connectors/terraform/provider/data_source_item_type.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/data_source_link.go
+++ b/connectors/terraform/provider/data_source_link.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/data_source_link_rule.go
+++ b/connectors/terraform/provider/data_source_link_rule.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/data_source_link_type.go
+++ b/connectors/terraform/provider/data_source_link_type.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/data_source_model.go
+++ b/connectors/terraform/provider/data_source_model.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 

--- a/connectors/terraform/provider/main.go
+++ b/connectors/terraform/provider/main.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"

--- a/connectors/terraform/provider/provider.go
+++ b/connectors/terraform/provider/provider.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"errors"

--- a/connectors/terraform/provider/provider_test.go
+++ b/connectors/terraform/provider/provider_test.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"testing"

--- a/connectors/terraform/provider/resource_item.go
+++ b/connectors/terraform/provider/resource_item.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
@@ -73,7 +73,7 @@ func createOrUpdateItem(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteItem(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, itemPayload(data), "item")
+	return delete(m, itemPayload(data), "item")
 }
 
 func itemPayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/resource_item_type.go
+++ b/connectors/terraform/provider/resource_item_type.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
@@ -53,7 +53,7 @@ func createOrUpdateItemType(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteItemType(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, itemTypePayload(data), "itemtype")
+	return delete(m, itemTypePayload(data), "itemtype")
 }
 
 func itemTypePayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/resource_link.go
+++ b/connectors/terraform/provider/resource_link.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
@@ -70,7 +70,7 @@ func createOrUpdateLink(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteLink(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, linkPayload(data), "link")
+	return delete(m, linkPayload(data), "link")
 }
 
 func linkPayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/resource_link_rule.go
+++ b/connectors/terraform/provider/resource_link_rule.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
@@ -62,7 +62,7 @@ func createOrUpdateLinkRule(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteLinkRule(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, linkRulePayload(data), "linkrule")
+	return delete(m, linkRulePayload(data), "linkrule")
 }
 
 func linkRulePayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/resource_link_type.go
+++ b/connectors/terraform/provider/resource_link_type.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
@@ -54,7 +54,7 @@ func createOrUpdateLinkType(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteLinkType(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, linkTypePayload(data), "linktype")
+	return delete(m, linkTypePayload(data), "linktype")
 }
 
 func linkTypePayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/resource_model.go
+++ b/connectors/terraform/provider/resource_model.go
@@ -13,7 +13,7 @@
    to be licensed under the same terms as the rest of the code.
 */
 
-package provider
+package main
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
@@ -56,7 +56,7 @@ func createOrUpdateModel(data *schema.ResourceData, m interface{}) error {
 }
 
 func deleteModel(data *schema.ResourceData, m interface{}) error {
-	return delete(data, m, modelPayload(data), "model")
+	return delete(m, modelPayload(data), "model")
 }
 
 func modelPayload(data *schema.ResourceData) Payload {

--- a/connectors/terraform/provider/types.go
+++ b/connectors/terraform/provider/types.go
@@ -12,7 +12,7 @@
    Contributors to this project, hereby assign copyright in this code to the project,
    to be licensed under the same terms as the rest of the code.
 */
-package provider
+package main
 
 import (
 	"bytes"

--- a/docs/models/aws_ec2/readme.md
+++ b/docs/models/aws_ec2/readme.md
@@ -5,3 +5,10 @@
 ![Metamodel](aws_ec2.png "AWS EC2 meta model")
 
 To import the model apply this [Terraform file](main.tf).
+
+N.B. You will first need to build the Onix Terraform provider and copy it to this directory:
+
+```
+cd connectors/terraform/provider
+make build
+cp terraform-provider-ox ../../../docs/models/aws_ec2/


### PR DESCRIPTION
Fixes to update the terraform provider to latest
`package main` is necessary to make the provider binary executable
Adjust the delete API signature changed in latest.
Add a comment to explain usage for the AWS EC2 model.