### PR TITLE
Updated mismatched test data

### DIFF
--- a/pilotctl/docker/items/area-east.json
+++ b/pilotctl/docker/items/area-east.json
@@ -1,5 +1,5 @@
 {
-  "name": "NORTH",
-  "description": "Represents the North region.",
+  "name": "EAST",
+  "description": "Represents the East region.",
   "type": "U_AREA"
 }

--- a/pilotctl/docker/items/area-north.json
+++ b/pilotctl/docker/items/area-north.json
@@ -1,5 +1,5 @@
 {
-  "name": "EAST",
-  "description": "Represents the West region.",
+  "name": "NORTH",
+  "description": "Represents the North region.",
   "type": "U_AREA"
 }

--- a/pilotctl/docker/items/area-south.json
+++ b/pilotctl/docker/items/area-south.json
@@ -1,5 +1,5 @@
 {
   "name": "SOUTH",
-  "description": "Represents the south region.",
+  "description": "Represents the South region.",
   "type": "U_AREA"
 }

--- a/pilotctl/docker/items/area-west.json
+++ b/pilotctl/docker/items/area-west.json
@@ -1,5 +1,5 @@
 {
-  "name": "EAST",
-  "description": "Represents the East region.",
+  "name": "WEST",
+  "description": "Represents the West region.",
   "type": "U_AREA"
 }


### PR DESCRIPTION
Area textual data was mismatched to the JSON files they were in, E.G. 

`area_north.json` contained:

```
{
  "name": "EAST",
  "description": "Represents the West region.",
  "type": "U_AREA"
}
```