### PR TITLE
new service manifest for PGAdmin and MongoDb GUI

### DIFF
--- a/deploy/onix.yaml
+++ b/deploy/onix.yaml
@@ -16,12 +16,25 @@ profiles:
       - name: pgadmin-app
       - name: mongodb-gui-app      
 
+  - name: full-test-data
+    description: deploys all services
+    services:
+      - name: db
+      - name: evr-mongo-db
+      - name: evr-mongo-app
+      - name: nexus-app
+      - name: artreg-app
+      - name: ox-app
+      - name: ox-app-test-data
+      - name: pilotctl-app
+      - name: pgadmin-app
+      - name: mongodb-gui-app
+      
   - name: config-db
     description: deploys the configuration database only
     services:
       - name: db
       - name: ox-app
-      - name: pgadmin-app      
         is:
           # overrides load-balanced behaviour in service
           load-balanced: 2
@@ -39,7 +52,7 @@ profiles:
     description: deploys nexus repository manager only
     services:
       - name: nexus-app
-      
+
 services:
   - name: db
     description: PostgreSQL Database service
@@ -89,6 +102,13 @@ services:
     is:
       public: wapi.onix.com
       encrypted-in-transit:
+
+  # image-less services run as a job, in this case to populate Onix database with test data
+  # note the definition does not define an image and the uri points to a service manifest which declares the
+  # scripts to run in one or more runtimes
+  - name: ox-app-test-data
+    description: add test data into the Onix database
+    uri: ../../deploy/svc/ox-app-test-data.yaml
 
   - name: pilotctl-app
     description: Pilot Control

--- a/deploy/onix.yaml
+++ b/deploy/onix.yaml
@@ -92,7 +92,7 @@ services:
 
   - name: pilotctl-app
     description: Pilot Control
-    uri: ./svc/pilotctl-app.yaml
+    uri: https://raw.githubusercontent.com/gatblau/onix/dev/deploy/svc/pilotctl-app.yaml
     schema_uri: https://raw.githubusercontent.com/gatblau/pilotctl-db/da13b0b770d5898327e95e0545266a229f0c837c
     image: quay.io/gatblau/pilotctl:0.0.4-161021085624494-f2346825d0
     port: "8888"
@@ -102,7 +102,7 @@ services:
 
   - name: pgadmin-app
     description: web gui client for postgresql database
-    uri: ./svc/pgadmin-app.yaml
+    uri: https://raw.githubusercontent.com/gatblau/onix/dev/deploy/svc/pgadmin-app.yaml
     image: docker.io/dpage/pgadmin4:latest
     port: "8083"
     is:
@@ -110,7 +110,7 @@ services:
 
   - name: mongodb-gui-app
     description: web gui client for mongo database
-    uri: ./svc/mongodb-gui-app.yaml
+    uri: https://raw.githubusercontent.com/gatblau/onix/dev/deploy/svc/mongodb-gui-app.yaml
     image: docker.io/mongo-express:latest
     port: "8084"
     is:

--- a/deploy/onix.yaml
+++ b/deploy/onix.yaml
@@ -13,24 +13,15 @@ profiles:
       - name: artreg-app
       - name: ox-app
       - name: pilotctl-app
-
-  - name: full-test-data
-    description: deploys all services
-    services:
-      - name: db
-      - name: evr-mongo-db
-      - name: evr-mongo-app
-      - name: nexus-app
-      - name: artreg-app
-      - name: ox-app
-      - name: ox-app-test-data
-      - name: pilotctl-app
+      - name: pgadmin-app
+      - name: mongodb-gui-app      
 
   - name: config-db
     description: deploys the configuration database only
     services:
       - name: db
       - name: ox-app
+      - name: pgadmin-app      
         is:
           # overrides load-balanced behaviour in service
           load-balanced: 2
@@ -48,7 +39,7 @@ profiles:
     description: deploys nexus repository manager only
     services:
       - name: nexus-app
-
+      
 services:
   - name: db
     description: PostgreSQL Database service
@@ -99,20 +90,29 @@ services:
       public: wapi.onix.com
       encrypted-in-transit:
 
-  # image-less services run as a job, in this case to populate Onix database with test data
-  # note the definition does not define an image and the uri points to a service manifest which declares the
-  # scripts to run in one or more runtimes
-  - name: ox-app-test-data
-    description: add test data into the Onix database
-    uri: ../../deploy/svc/ox-app-test-data.yaml
-
   - name: pilotctl-app
     description: Pilot Control
-    uri: https://raw.githubusercontent.com/gatblau/onix/dev/deploy/svc/pilotctl-app.yaml
+    uri: ./svc/pilotctl-app.yaml
     schema_uri: https://raw.githubusercontent.com/gatblau/pilotctl-db/da13b0b770d5898327e95e0545266a229f0c837c
     image: quay.io/gatblau/pilotctl:0.0.4-161021085624494-f2346825d0
     port: "8888"
     is:
       public: pilotctl.onix.com
       encrypted-in-transit:
+
+  - name: pgadmin-app
+    description: web gui client for postgresql database
+    uri: ./svc/pgadmin-app.yaml
+    image: docker.io/dpage/pgadmin4:latest
+    port: "8083"
+    is:
+      public: pgadmin.onix.com
+
+  - name: mongodb-gui-app
+    description: web gui client for mongo database
+    uri: ./svc/mongodb-gui-app.yaml
+    image: docker.io/mongo-express:latest
+    port: "8084"
+    is:
+      public: mongodbgui.onix.com
 ...

--- a/deploy/svc/mongodb-gui-app.yaml
+++ b/deploy/svc/mongodb-gui-app.yaml
@@ -1,0 +1,19 @@
+---
+name: mongodb-gui-app
+description: db web client for mongo database
+port: "8081"
+var:
+  - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+    description: the username to authenticate with the mongo database 
+    value: ${bind=evr-mongo-db:var:MONGO_INITDB_ROOT_USERNAME}
+  - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+    description: the password to authenticate with the mongo database
+    secret: true
+    value: ${bind=evr-mongo-db:var:MONGO_INITDB_ROOT_PASSWORD}
+  - name: ME_CONFIG_MONGODB_ENABLE_ADMIN
+    description: whether to enable admin
+    value: "true"
+  - name: ME_CONFIG_MONGODB_SERVER
+    description: the name of the mongo service which this gui app has to connect
+    value: ${bind=evr-mongo-db}
+...

--- a/deploy/svc/ox-app.yaml
+++ b/deploy/svc/ox-app.yaml
@@ -12,7 +12,7 @@ var:
   - name: DB_PWD
     description: the password to authenticate with the database service
     secret: true
-    value: ${fx=pwd:16,false}
+    value: ${fx=pwd:16,false}123
   - name: DB_ADMIN_USER
     description: the username to authenticate with the database services
     value: "postgres"

--- a/deploy/svc/pgadmin-app.yaml
+++ b/deploy/svc/pgadmin-app.yaml
@@ -1,0 +1,33 @@
+---
+name: pgadmin-app
+description: db web client for postgresql
+port: "80"
+var:
+  - name: PGADMIN_DEFAULT_EMAIL
+    description: the default user id which will be used to login to pgadmin web console
+    value: "admin@local.com"
+  - name: PGADMIN_DEFAULT_PASSWORD
+    description: the password to authenticate user to pgadmin web console
+    secret: true
+    value: ${fx=pwd:16,false}
+  - name: PGADMIN_SERVER_JSON_FILE
+    description: the port the http
+    value: "/pgadmin4/onix/postgres_servers.json"
+file:
+  - path: /pgadmin4/onix/postgres_servers.json
+    description: the configuration of event receivers used by pilotctl to send events
+    template: |
+      {
+        "Servers": {
+          "1": {
+            "Name": "Main Onix database",
+            "Group": "Onix",
+            "Port": 5432,
+            "Host": "${bind=db}",
+            "Username": "${bind=ox-app:var:DB_ADMIN_USER}",            
+            "MaintenanceDB": "postgres",
+            "SSLMode": "disable"
+          }
+        }
+      }
+...

--- a/deploy/svc/pilotctl-app.yaml
+++ b/deploy/svc/pilotctl-app.yaml
@@ -166,7 +166,7 @@ file:
             "pwd": "${bind=evr-mongo-app:var:OX_HTTP_PWD}"{{ $count := plus $count 1 }}
           }{{ end }}{{ if gt $count 1 }},{{ end }}
         ]
-      }
+      }      
 db:
   name: pilotctl
   app_version: 0.0.4
@@ -178,6 +178,10 @@ db:
   admin_user: postgres
   admin_pwd: ${bind=db:var:POSTGRES_PASSWORD}
   schema_uri: ${bind=pilotctl-app:schema_uri}
+init:	
+  - builder: compose	
+    scripts:	
+      - create_pilotctl_user  
 scripts:
   - name: create_pilotctl_user
     description: |

--- a/deploy/svc/pilotctl-app.yaml
+++ b/deploy/svc/pilotctl-app.yaml
@@ -39,6 +39,19 @@ var:
     description: the password to authenticate with the Artisan Registry service
     secret: true
     value: ${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD}
+  - name: PILOTCTL_ONIX_EMAIL
+    description: Demo email for dashboard logon
+    value: "demouser@onix.com"
+  - name: PILOTCTL_ONIX_USER
+    description: Demo user for dashboard logon
+    value: "demouser"
+  - name: PILOTCTL_ONIX_PWD
+    description: Password for demouser dashboard logon
+    secret: true
+    value: ${fx=pwd:13,true}123
+  - name: OX_ART_REG_PACKAGE_FILTER
+    description: Filter for retrieving Artisan registry packages through pilotctl
+    value: "aps/"    
 file:
   - path: /keys/.pilot_verify.pgp
     description: the public pgp key used by pilot to verify connections to pilot control
@@ -165,4 +178,16 @@ db:
   admin_user: postgres
   admin_pwd: ${bind=db:var:POSTGRES_PASSWORD}
   schema_uri: ${bind=pilotctl-app:schema_uri}
+scripts:
+  - name: create_pilotctl_user
+    description: |
+      creates the main pilotctl user in Onix
+    runtime: ubi-min
+    content: |
+      echo "updating Onix admin password from default ..."
+      art curl -X PUT \
+        -u "${bind=ox-app:var:WAPI_ADMIN_USER}:${bind=ox-app:var:WAPI_ADMIN_PWD}" \
+        -H 'Content-Type: application/json' \
+        "http://${bind=ox-app}":"${bind=ox-app:port}"/user/ONIX_PILOTCTL \
+        -d "{\"email\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_EMAIL}\", \"name\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_USER}\", \"pwd\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_PWD}\", \"service\":\"false\", \"acl\":\"*:*:*\"}"
 ...

--- a/wapi/src/main/java/org/gatblau/onix/Lib.java
+++ b/wapi/src/main/java/org/gatblau/onix/Lib.java
@@ -183,8 +183,10 @@ public class Lib implements InitializingBean {
     public UserData toUserData(ResultSet set) throws SQLException {
         UserData user = null;
         if (set != null) {
-            Date updated = set.getDate("updated");
-            Date expires = set.getDate("expires");
+            Date updated = set.getTimestamp("updated");
+            Date expires = set.getTimestamp("expires");
+            Date created = set.getTimestamp("created");
+
             user = new UserData();
             user.setKey(set.getString("key"));
             user.setName(set.getString("name"));
@@ -197,6 +199,7 @@ public class Lib implements InitializingBean {
             user.setAcl(set.getString("acl"));
             user.setVersion(set.getInt("version"));
             user.setChangedBy(set.getString("changed_by"));
+            user.setCreated((created != null) ? dateFormat.format(created) : null);
         }
         return user;
     }


### PR DESCRIPTION
1> created new service manifest for PGAdmin and MongoDb GUI
2> added above service entries into onix.yaml
3> added steps to handle onix password policy restriction of minimum two digits in ox-app and pilotctl-app service manifest (copied from aps-library which Steve implemented)
4> added steps to create pilotctl wapi  (copied from aps-library which Steve implemented)