### PR TITLE
changes to app manifest and fixes to service manifest

### DIFF
--- a/deploy/onix.yaml
+++ b/deploy/onix.yaml
@@ -81,7 +81,8 @@ services:
     image: sonatype/nexus3
     port:
       http: "8081"
-      docker: "5000"
+      docker-http: "5000"
+      docker-https: "5001"
     is:
       public: nexus.onix.com
       encrypted-in-transit:

--- a/deploy/svc/artreg-app.yaml
+++ b/deploy/svc/artreg-app.yaml
@@ -12,7 +12,7 @@ var:
     value: ${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD}
   - name: OXA_HTTP_PORT
     description: the port on which the registry HTTP API service listens
-    value: "8080"
+    value: ${bind=artreg-app:port}
   - name: OXA_HTTP_BACKEND_DOMAIN
     description: the URI of the HTTP backend service to use
     value: "http://${bind=nexus-app}:${bind=nexus-app:port[http]}"
@@ -22,4 +22,39 @@ var:
   - name: OXA_HTTP_UPLOAD_LIMIT
     description: the maximum size of artisan packages (in MB) allowed to be pushed to the registry
     value: "30"
+init:
+  - builder: compose
+    scripts:
+      - create_artisan_repo
+scripts:
+  - name: create_artisan_repo
+    description: |
+      create new artisan hosted repository in nexus
+    runtime: ubi-min
+    content: |
+      echo "creating new artisan hosted repository in nexus"
+      art curl -X POST \
+        -u admin:${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD} \
+        http://${bind=nexus-app}:${bind=nexus-app:port[http]}/service/rest/v1/repositories/raw/hosted \
+        -H 'accept: application/json','Content-Type: application/json' \
+        -d '{
+        "name": "artisan",
+        "online": true,
+        "storage": {
+          "blobStoreName": "default",
+          "strictContentTypeValidation": true,
+          "writePolicy": "allow"
+        },
+        "cleanup": {
+          "policyNames": [
+            "string"
+          ]
+        },
+        "component": {
+          "proprietaryComponents": true
+        },
+        "raw": {
+          "contentDisposition": "ATTACHMENT"
+        }
+      }'
 ...

--- a/deploy/svc/evr-mongo-app.yaml
+++ b/deploy/svc/evr-mongo-app.yaml
@@ -9,7 +9,7 @@ var:
     secret: true
   - name: OX_HTTP_PORT
     description: the HTTP port on which the event receiver service listens
-    value: "8080"
+    value: ${bind=evr-mongo-app:port}
   - name: OX_HTTP_UNAME
     description: the user to authenticate with the event receiver HTTP service
     value: ${fx=name:99}

--- a/deploy/svc/nexus-app.yaml
+++ b/deploy/svc/nexus-app.yaml
@@ -3,12 +3,16 @@ name: nexus-app
 description: Nexus 3 repository manager
 port:
   http: "8081"
-  docker: "5000"
+  docker-http: "5000"
+  docker-https: "5001"
 var:
   - name: NEXUS_ADMIN_PASSWORD
     description: the nexus admin password
     secret: true
     value: ${fx=pwd:16,false}
+  - name: SETUP_DOCKER_REGISTRY
+    description: Whether to setup docker registry with in Nexus.
+    value: true    
 volume:
   - name: nexus-data
     path: /nexus-data
@@ -55,36 +59,41 @@ scripts:
 
       rm temppwd
 
-      echo "creating new artisan hosted repository in nexus"
-      art curl -X POST \
-        -u admin:${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD} \
-        http://${bind=nexus-app}:${bind=nexus-app:port[http]}/service/rest/v1/repositories/raw/hosted \
-        -H 'accept: application/json','Content-Type: application/json' \
-        -d '{
-        "name": "artisan",
-        "online": true,
-        "storage": {
-          "blobStoreName": "default",
-          "strictContentTypeValidation": true,
-          "writePolicy": "allow"
-        },
-        "cleanup": {
-          "policyNames": [
-            "string"
-          ]
-        },
-        "component": {
-          "proprietaryComponents": true
-        },
-        "raw": {
-          "contentDisposition": "ATTACHMENT"
-        }
-      }'
-
       echo "disabling nexus anonymous access"
       art curl -X PUT \
         -u admin:${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD} \
         http://${bind=nexus-app}:${bind=nexus-app:port[http]}/service/rest/v1/security/anonymous \
         -H 'accept: application/json','Content-Type: application/json' \
         -d '{"enabled": false}'
+      
+      if ${bind=nexus-app:var:SETUP_DOCKER_REGISTRY} ; then
+        echo "creating new artisan docker registry in nexus"
+        art curl -X POST \
+          -u admin:${bind=nexus-app:var:NEXUS_ADMIN_PASSWORD} \
+          http://${bind=nexus-app}:${bind=nexus-app:port[http]}/service/rest/v1/repositories/docker/hosted \
+          -H 'accept: application/json','Content-Type: application/json' \
+          -d '{
+          "name": "aps-docker-registry",
+          "online": true,
+          "storage": {
+            "blobStoreName": "default",
+            "strictContentTypeValidation": true,
+            "writePolicy": "allow"
+          },
+          "cleanup": {
+            "policyNames": [
+              "string"
+            ]
+          },
+          "component": {
+            "proprietaryComponents": true
+          },
+          "docker": {
+            "v1Enabled": false,
+            "forceBasicAuth": true,
+            "httpPort": ${bind=nexus-app:port[docker-http]},
+            "httpsPort": ${bind=nexus-app:port[docker-https]}
+          }
+        }'
+      fi
 ...

--- a/deploy/svc/ox-app.yaml
+++ b/deploy/svc/ox-app.yaml
@@ -29,7 +29,7 @@ var:
   - name: WAPI_ADMIN_PWD
     description: the password to authenticate with the web api as admin
     secret: true
-    value: ${fx=pwd:16,false}
+    value: ${fx=pwd:16,false}123
   - name: WAPI_EVENTS_ENABLED
     description: whether sending of mqtt messages is enabled for changes to configuration data
     value: "false"
@@ -59,6 +59,6 @@ scripts:
         -a 25 \
         -u "admin:0n1x" \
         -H "Content-Type: application/json" \
-        "http://${bind=ox-app}":"${bind=ox-app:port}"/user/"${OX_APP_WAPI_ADMIN_USER}"/pwd \
-        -d "{\"pwd\":\"${OX_APP_WAPI_ADMIN_PWD}\"}"
+        "http://${bind=ox-app}":"${bind=ox-app:port}"/user/"${bind=ox-app:var:WAPI_ADMIN_USER}"/pwd \
+        -d "{\"pwd\":\"${bind=ox-app:var:WAPI_ADMIN_PWD}\"}"
 ...

--- a/deploy/svc/pilotctl-app.yaml
+++ b/deploy/svc/pilotctl-app.yaml
@@ -15,10 +15,10 @@ var:
     value: ${fx=pwd:16,false}
   - name: OX_HTTP_PORT
     description: the port the http
-    value: "8888"
+    value: ${bind=pilotctl-app:port}
   - name: OX_WAPI_URI
-    description: the URI of the Onix Web API service used by pilot control to store configuration data
-    value: ${bind=ox-app}
+    description: the URI of the Onix Web API service used by pilot control to store configuration data (must include port)
+    value: http://${bind=ox-app}:${bind=ox-app:port}
   - name: OX_WAPI_USER
     description: the username to authenticate with the Onix Web API service
     value: ${bind=ox-app:var:WAPI_ADMIN_USER}
@@ -31,7 +31,7 @@ var:
     value: "false"
   - name: OX_ART_REG_URI
     description: the URI of the Artisan registry service used by pilot control to look up automation packages
-    value: ${bind=artreg-app}
+    value: http://${bind=artreg-app}:${bind=artreg-app:port}
   - name: OX_ART_REG_USER
     description: the username to authenticate with the Artisan Registry service
     value: ${bind=artreg-app:var:OXA_HTTP_UNAME}
@@ -188,10 +188,10 @@ scripts:
       creates the main pilotctl user in Onix
     runtime: ubi-min
     content: |
-      echo "updating Onix admin password from default ..."
+      echo "creating pilotctl user ..."
       art curl -X PUT \
         -u "${bind=ox-app:var:WAPI_ADMIN_USER}:${bind=ox-app:var:WAPI_ADMIN_PWD}" \
         -H 'Content-Type: application/json' \
-        "http://${bind=ox-app}":"${bind=ox-app:port}"/user/ONIX_PILOTCTL \
+        "http://${bind=ox-app}":"${bind=ox-app:port}"/user/ONIX_PILOTCTL?notify=false \
         -d "{\"email\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_EMAIL}\", \"name\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_USER}\", \"pwd\":\"${bind=pilotctl-app:var:PILOTCTL_ONIX_PWD}\", \"service\":\"false\", \"acl\":\"*:*:*\"}"
 ...


### PR DESCRIPTION

1.  Modified Onix.yaml, to use http and https port for docker setup on nexus
2.  Amended artreg-app.yaml, to remove hardcoded port number in variable and also added init script to setup artisan registry (this was done initial when nexus was getting deployed)
3. Amended evr-mongo-app.yaml, to remove hardcoded port number in variable
4. Amended nexus-app.yaml, to set http and https port for docker. Added variable to decided where docker registry has to be setup in nexus. Added code to setup docker registry. Removed code which was setting up new artisan repository (this is moved to artreg-app.yaml service manifest )
5. Amended ox-app.yaml, to add 123 to password so that the password follows  Onix db policy rule. Modified curl section, now hardcoded variable is replaced by binding approach
6. Amended pilotctl-app.yaml, to remove hardcoded port number in variable. OX_WAPI_URI is modified by added port number into it. Pilot control user creation curl command is modified to pass the notify=false in the request so that email is not triggered.