### PR TITLE
Configurable CORS

### DIFF
--- a/pilotctl/core/conf.go
+++ b/pilotctl/core/conf.go
@@ -9,6 +9,7 @@ package core
 */
 import (
 	"fmt"
+	"errors"
 	"log"
 	"os"
 	"strconv"
@@ -36,6 +37,8 @@ const (
 	ConfActPwd                   ConfKey = "OX_PILOTCTL_ACTIVATION_PWD"
 	ConfTenant                   ConfKey = "OX_PILOTCTL_TENANT"
 	ConfDbMaxConn                ConfKey = "OX_PILOTCTL_DB_MAXCONN"
+	ConfCorsOrigin               ConfKey = "OX_PILOTCTL_CORS_ORIGIN"
+	ConfCorsHeaders              ConfKey = "OX_PILOTCTL_CORS_HEADERS"
 )
 
 type Conf struct {
@@ -146,6 +149,16 @@ func (c *Conf) getValue(key ConfKey) string {
 	return value
 }
 
+func (c *Conf) getValueWithError(key ConfKey) (string, error) {
+	value := os.Getenv(string(key))
+	if len(value) == 0 {
+		error := fmt.Sprintf("WARNING: variable %s not definedg", key)
+		log.Printf(error)
+		return "", errors.New(error)
+	}
+	return value, nil
+}
+
 func (c *Conf) getOxWapiInsecureSkipVerify() bool {
 	b, err := strconv.ParseBool(c.getValue(ConfOxWapiInsecureSkipVerify))
 	if err != nil {
@@ -168,3 +181,21 @@ func (c *Conf) getDbMaxConn() int {
 	}
 	return maxConn
 }
+
+func (c *Conf) GetCorsOrigin() string {
+	value, err := c.getValueWithError(ConfCorsOrigin)
+	if err != nil {
+		log.Printf("WARNING: will not allow CORS")
+	}
+	return value
+}
+
+func (c *Conf) GetCorsHeaders() string {
+	value, err := c.getValueWithError(ConfCorsHeaders)
+	if err != nil {
+		log.Printf("WARNING: will block headers such as Authorization and Origin on CORS OPTIONS requests")
+	}
+	return value
+}
+
+

--- a/pilotctl/main.go
+++ b/pilotctl/main.go
@@ -24,8 +24,17 @@ func main() {
 		// enable encoded path  vars
 		router.UseEncodedPath()
 		// middleware
-		// router.Use(s.LoggingMiddleware)
+		router.Use(s.LoggingMiddleware)
 		router.Use(s.AuthenticationMiddleware)
+		router.Use(mux.CORSMethodMiddleware(router))
+		
+		// we have to process cfg here and not pass it to
+		// CorsMiddlewhare because it will create
+		// circular dependency for now
+		cfg := core.NewConf()
+		origin := cfg.GetCorsOrigin()
+		headers := cfg.GetCorsHeaders()
+		router.Use(s.CorsMiddleware(origin, headers))
 
 		// pilot http handlers
 		router.HandleFunc("/ping", pingHandler).Methods("POST")
@@ -44,7 +53,7 @@ func main() {
 		router.Handle("/org-group/{org-group}/org", s.Authorise(getOrgHandler)).Methods("GET")
 		router.Handle("/area/{area}/location", s.Authorise(getLocationsHandler)).Methods("GET")
 		router.Handle("/admission", s.Authorise(setAdmissionHandler)).Methods("PUT")
-		router.Handle("/package", s.Authorise(getPackagesHandler)).Methods("GET")
+		router.Handle("/package", s.Authorise(getPackagesHandler)).Methods(http.MethodGet, http.MethodOptions)
 		router.Handle("/package/{name}/api", s.Authorise(getPackagesApiHandler)).Methods("GET")
 		router.Handle("/job", s.Authorise(newJobHandler)).Methods("POST")
 		router.Handle("/job", s.Authorise(getJobsHandler)).Methods("GET")


### PR DESCRIPTION
Added 2 variables:

* `OX_PILOTCTL_CORS_ORIGIN`
* `OX_PILOTCTL_CORS_HEADERS`

This enables *Pilotctl* to be called from web apps at a different origin. We currently have a use case for that where we have multiple UI's in different origins accessing *Pilotctl*

Example:

```
cat >> $ENV_FILE <<EOF
OX_WAPI_URI=http://localhost:9009
OX_PILOTCTL_DB_HOST=localhost
OX_PILOTCTL_CORS_ORIGIN=http://example.com:9090
OX_PILOTCTL_CORS_HEADERS="Origin, Authorization"
EOF
``` 