### PR TITLE
Changes to onix client lib and error handling after http request was made

### DIFF
--- a/artisan/core/http.go
+++ b/artisan/core/http.go
@@ -11,13 +11,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gatblau/onix/oxlib/httpserver"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/gatblau/onix/oxlib/httpserver"
 )
 
 // Get make a GET HTTP request to the specified URL
@@ -33,6 +34,9 @@ func Get(url, user, pwd string) (*http.Response, error) {
 	}
 	// issue http request
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return resp, errors.New(fmt.Sprintf("error: response was empty for resource: %s", url))

--- a/artisan/doorman/core/process.go
+++ b/artisan/doorman/core/process.go
@@ -12,6 +12,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/gatblau/onix/artisan/build"
 	"github.com/gatblau/onix/artisan/core"
 	"github.com/gatblau/onix/artisan/doorman/types"
@@ -19,12 +26,6 @@ import (
 	"github.com/gatblau/onix/artisan/merge"
 	"github.com/gatblau/onix/artisan/registry"
 	util "github.com/gatblau/onix/oxlib/httpserver"
-	"net/http"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
 )
 
 type Processor struct {
@@ -500,6 +501,9 @@ func postNotification(n NotificationMsg) error {
 	req.Header.Add("Authorization", util.BasicToken(user, pwd))
 	req.Header.Add("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return fmt.Errorf("response was empty for resource: %s", requestURI)

--- a/artisan/doorman/proxy/http.go
+++ b/artisan/doorman/proxy/http.go
@@ -10,8 +10,9 @@ package main
 
 import (
 	"fmt"
-	util "github.com/gatblau/onix/oxlib/httpserver"
 	"net/http"
+
+	util "github.com/gatblau/onix/oxlib/httpserver"
 )
 
 func newRequest(method, requestURI string) (*http.Response, error, int) {
@@ -29,6 +30,10 @@ func newRequest(method, requestURI string) (*http.Response, error, int) {
 	}
 	req.Header.Add("Authorization", util.BasicToken(user, pwd))
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err, http.StatusBadGateway
+	}
+
 	// do we have a nil response?
 	if resp == nil {
 		return nil, fmt.Errorf("response was empty for resource: %s", requestURI), http.StatusBadGateway

--- a/oxlib/oxc/client.go
+++ b/oxlib/oxc/client.go
@@ -58,8 +58,8 @@ type HttpRequestProcessor func(req *http.Request, payload Serializable) error
 
 // Onix HTTP client
 type Client struct {
+	*http.Client
 	conf  *ClientConf
-	self  *http.Client
 	token string
 }
 
@@ -128,7 +128,7 @@ func NewClient(conf *ClientConf) (*Client, error) {
 		// the authentication token
 		token: token,
 		// the http client instance
-		self: &http.Client{
+		Client: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: conf.InsecureSkipVerify,
@@ -164,8 +164,10 @@ func (c *Client) MakeRequest(method string, url string, payload Serializable, pr
 	}
 
 	// submits the request
-	resp, err := http.DefaultClient.Do(req)
-
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return resp, errors.New(fmt.Sprintf("error: response was empty for resource: %s, check the service is up and running", url))
@@ -207,7 +209,10 @@ func (c *Client) Get(url string, processor HttpRequestProcessor) (*http.Response
 		}
 	}
 	// issue http request
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return resp, errors.New(fmt.Sprintf("error: response was empty for resource: %s", url))

--- a/pilot/core/pilot.go
+++ b/pilot/core/pilot.go
@@ -12,13 +12,14 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"github.com/gatblau/oxc"
-	"github.com/rs/zerolog/log"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/gatblau/oxc"
+	"github.com/rs/zerolog/log"
 )
 
 // pilot monitors and reloads application configuration
@@ -343,7 +344,9 @@ func (p *pilot) http(method string, url string, payload string, headers http.Hea
 
 	// submits the request
 	resp, err := http.DefaultClient.Do(req)
-
+	if err != nil {
+		return nil, err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return resp, errors.New(fmt.Sprintf("error: response was empty for resource: %s, check the service is up and running", url))

--- a/pilotctl/core/client.go
+++ b/pilotctl/core/client.go
@@ -168,6 +168,9 @@ func (c *Client) Get(url string, processor HttpRequestProcessor) (*http.Response
 	}
 	// issue http request
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	// do we have a nil response?
 	if resp == nil {
 		return resp, errors.New(fmt.Sprintf("error: response was empty for resource: %s", url))


### PR DESCRIPTION
1> Changed onix client lib, so that configurations like skip tls check are set properly.
2> Some files had missing error check condition after http request was made. In those places added step to check if error is not nil then return the error.